### PR TITLE
Refactor MusicalSymbol to Use Named Constructor Instead of Enum in Arguments (#16)

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -37,7 +37,7 @@ class SimpleSheetMusicDemoState extends State {
   void initState() {
     measure1 = Measure([
       const Clef.treble(),
-      const KeySignature(KeySignatureType.dMajor),
+      const KeySignature.dMajor(),
       const ChordNote([
         ChordNotePart(Pitch.b4),
         ChordNotePart(Pitch.g5, accidental: Accidental.sharp),
@@ -58,7 +58,7 @@ class SimpleSheetMusicDemoState extends State {
     measure3 = Measure(
       [
         const Clef.bass(),
-        const KeySignature(KeySignatureType.cMinor),
+        const KeySignature.cMinor(),
         const ChordNote(
           [
             ChordNotePart(Pitch.c2),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -36,7 +36,7 @@ class SimpleSheetMusicDemoState extends State {
   @override
   void initState() {
     measure1 = Measure([
-      const Clef(ClefType.treble),
+      const Clef.treble(),
       const KeySignature(KeySignatureType.dMajor),
       const ChordNote([
         ChordNotePart(Pitch.b4),
@@ -57,7 +57,7 @@ class SimpleSheetMusicDemoState extends State {
     ]);
     measure3 = Measure(
       [
-        const Clef(ClefType.bass),
+        const Clef.bass(),
         const KeySignature(KeySignatureType.cMinor),
         const ChordNote(
           [

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -161,7 +161,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.4-dev.1"
+    version: "1.0.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/lib/simple_sheet_music.dart
+++ b/lib/simple_sheet_music.dart
@@ -7,7 +7,7 @@ library simple_sheet_music;
 export '/src/font_types.dart' show FontType;
 export '/src/measure/measure.dart' show Measure;
 export '/src/music_objects/clef/clef.dart' show Clef;
-export '/src/music_objects/clef/clef_type.dart' show ClefType;
+// export '/src/music_objects/clef/clef_type.dart' show ClefType;
 export '/src/simple_sheet_music.dart' show SimpleSheetMusic;
 export 'src/music_objects/key_signature/key_signature.dart' show KeySignature;
 export 'src/music_objects/key_signature/keysignature_type.dart'

--- a/lib/simple_sheet_music.dart
+++ b/lib/simple_sheet_music.dart
@@ -7,11 +7,8 @@ library simple_sheet_music;
 export '/src/font_types.dart' show FontType;
 export '/src/measure/measure.dart' show Measure;
 export '/src/music_objects/clef/clef.dart' show Clef;
-// export '/src/music_objects/clef/clef_type.dart' show ClefType;
 export '/src/simple_sheet_music.dart' show SimpleSheetMusic;
 export 'src/music_objects/key_signature/key_signature.dart' show KeySignature;
-export 'src/music_objects/key_signature/keysignature_type.dart'
-    show KeySignatureType;
 export 'src/music_objects/notes/accidental.dart' show Accidental;
 export 'src/music_objects/notes/chord_note/chord_note.dart' show ChordNote;
 export 'src/music_objects/notes/chord_note/chord_note_part.dart'

--- a/lib/src/music_objects/clef/clef.dart
+++ b/lib/src/music_objects/clef/clef.dart
@@ -11,11 +11,6 @@ import 'package:simple_sheet_music/src/sheet_music_layout.dart';
 
 /// Represents a musical clef symbol.
 class Clef implements MusicalSymbol {
-  // const Clef(
-  //   this.clefType, {
-  //   this.margin = const EdgeInsets.all(10),
-  //   this.color = Colors.black,
-  // });
 
   const Clef.treble({
     this.margin = const EdgeInsets.all(10),

--- a/lib/src/music_objects/clef/clef.dart
+++ b/lib/src/music_objects/clef/clef.dart
@@ -11,11 +11,31 @@ import 'package:simple_sheet_music/src/sheet_music_layout.dart';
 
 /// Represents a musical clef symbol.
 class Clef implements MusicalSymbol {
-  const Clef(
-    this.clefType, {
+  // const Clef(
+  //   this.clefType, {
+  //   this.margin = const EdgeInsets.all(10),
+  //   this.color = Colors.black,
+  // });
+
+  const Clef.treble({
     this.margin = const EdgeInsets.all(10),
     this.color = Colors.black,
-  });
+  }) : clefType = ClefType.treble;
+
+  const Clef.alto({
+    this.margin = const EdgeInsets.all(10),
+    this.color = Colors.black,
+  }) : clefType = ClefType.alto;
+
+  const Clef.tenor({
+    this.margin = const EdgeInsets.all(10),
+    this.color = Colors.black,
+  }) : clefType = ClefType.tenor;
+
+  const Clef.bass({
+    this.margin = const EdgeInsets.all(10),
+    this.color = Colors.black,
+  }) : clefType = ClefType.bass;
 
   /// The type of the clef.
   final ClefType clefType;

--- a/lib/src/music_objects/key_signature/key_signature.dart
+++ b/lib/src/music_objects/key_signature/key_signature.dart
@@ -13,11 +13,156 @@ import 'package:simple_sheet_music/src/musical_context.dart';
 import 'package:simple_sheet_music/src/sheet_music_layout.dart';
 
 class KeySignature implements MusicalSymbol {
-  const KeySignature(
-    this.keySignatureType, {
+  const KeySignature.cMajor({
     this.color = Colors.black,
     this.margin = const EdgeInsets.all(10),
-  });
+  }) : keySignatureType = KeySignatureType.cMajor;
+
+  const KeySignature.aMinor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.aMinor;
+
+  const KeySignature.gMajor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.gMajor;
+
+  const KeySignature.eMinor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.eMinor;
+
+  const KeySignature.dMajor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.dMajor;
+
+  const KeySignature.bMinor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.bMinor;
+
+  const KeySignature.aMajor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.aMajor;
+
+  const KeySignature.fSharpMinor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.fSharpMinor;
+
+  const KeySignature.eMajor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.eMajor;
+
+  const KeySignature.cSharpMinor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.cSharpMinor;
+
+  const KeySignature.bMajor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.bMajor;
+
+  const KeySignature.gSharpMinor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.gSharpMinor;
+
+  const KeySignature.fSharpMajor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.fSharpMajor;
+
+  const KeySignature.dSharpMinor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.dSharpMinor;
+
+  const KeySignature.cSharpMajor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.cSharpMajor;
+
+  const KeySignature.aSharpMinor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.aSharpMinor;
+
+  const KeySignature.fMajor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.fMajor;
+
+  const KeySignature.dMinor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.dMinor;
+
+  const KeySignature.bFlatMajor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.bFlatMajor;
+
+  const KeySignature.gMinor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.gMinor;
+
+  const KeySignature.eFlatMajor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.eFlatMajor;
+
+  const KeySignature.cMinor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.cMinor;
+
+  const KeySignature.aFlatMajor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.aFlatMajor;
+
+  const KeySignature.fMinor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.fMinor;
+
+  const KeySignature.dFlatMajor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.dFlatMajor;
+
+  const KeySignature.bFlatMinor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.bFlatMinor;
+
+  const KeySignature.gFlatMajor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.gFlatMajor;
+
+  const KeySignature.eFlatMinor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.eFlatMinor;
+
+  const KeySignature.cFlatMajor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.cFlatMajor;
+
+  const KeySignature.aFlatMinor({
+    this.color = Colors.black,
+    this.margin = const EdgeInsets.all(10),
+  }) : keySignatureType = KeySignatureType.aFlatMinor;
+
   final KeySignatureType keySignatureType;
 
   @override

--- a/test/measure/measure_test.dart
+++ b/test/measure/measure_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:simple_sheet_music/simple_sheet_music.dart';
+import 'package:simple_sheet_music/src/music_objects/clef/clef_type.dart';
 import 'package:simple_sheet_music/src/music_objects/interface/musical_symbol_metrics.dart';
 import 'package:simple_sheet_music/src/musical_context.dart';
 
@@ -15,9 +16,9 @@ void main() {
     const context = MusicalContext(ClefType.treble, KeySignatureType.cMajor);
 
     final musicalSymbols = [
-      const Clef(ClefType.treble),
+      const Clef.treble(),
       MockMusicalSymbol(),
-      const Clef(ClefType.bass),
+      const Clef.bass(),
       MockMusicalSymbol(),
     ];
     final measure = Measure(musicalSymbols);
@@ -51,9 +52,9 @@ void main() {
 
   test('Measure should return the last clef type', () {
     final musicalSymbols = [
-      const Clef(ClefType.treble),
+      const Clef.treble(),
       MockMusicalSymbol(),
-      const Clef(ClefType.bass),
+      const Clef.bass(),
       MockMusicalSymbol(),
     ];
     final measure = Measure(musicalSymbols);
@@ -82,7 +83,7 @@ void main() {
         MusicalContext(initialClefType, initialKeySignatureType);
 
     final musicalSymbols = [
-      const Clef(ClefType.bass),
+      const Clef.bass(),
       MockMusicalSymbol(),
       const KeySignature(KeySignatureType.aMinor),
       MockMusicalSymbol(),

--- a/test/measure/measure_test.dart
+++ b/test/measure/measure_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:simple_sheet_music/simple_sheet_music.dart';
 import 'package:simple_sheet_music/src/music_objects/clef/clef_type.dart';
 import 'package:simple_sheet_music/src/music_objects/interface/musical_symbol_metrics.dart';
+import 'package:simple_sheet_music/src/music_objects/key_signature/keysignature_type.dart';
 import 'package:simple_sheet_music/src/musical_context.dart';
 
 import '../mock/mocks.dart';
@@ -65,9 +66,9 @@ void main() {
 
   test('Measure should return the last key signature type', () {
     final musicalSymbols = [
-      const KeySignature(KeySignatureType.cMajor),
+      const KeySignature.cMajor(),
       MockMusicalSymbol(),
-      const KeySignature(KeySignatureType.aMinor),
+      const KeySignature.aMinor(),
       MockMusicalSymbol(),
     ];
     final measure = Measure(musicalSymbols);
@@ -85,7 +86,7 @@ void main() {
     final musicalSymbols = [
       const Clef.bass(),
       MockMusicalSymbol(),
-      const KeySignature(KeySignatureType.aMinor),
+      const KeySignature.aMinor(),
       MockMusicalSymbol(),
     ];
     final measure = Measure(musicalSymbols);

--- a/test/musical_context_test.dart
+++ b/test/musical_context_test.dart
@@ -11,7 +11,7 @@ void main() {
     // Arrange
     const musicalContext =
         MusicalContext(ClefType.treble, KeySignatureType.cMajor);
-    const clef = Clef(ClefType.bass);
+    const clef = Clef.bass();
 
     // Act
     final updatedContext = musicalContext.update(clef);

--- a/test/musical_context_test.dart
+++ b/test/musical_context_test.dart
@@ -26,7 +26,7 @@ void main() {
     // Arrange
     const musicalContext =
         MusicalContext(ClefType.treble, KeySignatureType.cMajor);
-    const keySignature = KeySignature(KeySignatureType.aFlatMinor);
+    const keySignature = KeySignature.aFlatMinor();
 
     // Act
     final updatedContext = musicalContext.update(keySignature);


### PR DESCRIPTION
This pull request refactors the MusicalSymbol by replacing the enum in its arguments with a named constructor. Changes include updates to clef and key signature. By keeping clefType and keySignatureType hidden from library users, we aim to reduce confusion and improve the overall usability of the library.