### PR TITLE
Respect ancestor onTap event.

### DIFF
--- a/lib/src/simple_sheet_music.dart
+++ b/lib/src/simple_sheet_music.dart
@@ -110,14 +110,9 @@ class SimpleSheetMusicState extends State<SimpleSheetMusic> {
           widgetWidth: widget.width,
           widgetHeight: widget.height,
         );
-        return GestureDetector(
-          onTap: () {
-            // print('Tapped');
-          },
-          child: CustomPaint(
-            size: targetSize,
-            painter: SheetMusicRenderer(layout),
-          ),
+        return CustomPaint(
+          size: targetSize,
+          painter: SheetMusicRenderer(layout),
         );
       },
     );


### PR DESCRIPTION
Removal of the GestureDetector with an empty onTap event allows for ancestor onTap events to fire instead of the inner class overriding the function call.