### PR TITLE
feat: add bar line support to measures

### DIFF
--- a/lib/simple_sheet_music.dart
+++ b/lib/simple_sheet_music.dart
@@ -5,10 +5,13 @@
 library simple_sheet_music;
 
 export '/src/font_types.dart' show FontType;
+export '/src/measure/bar_line_type.dart' show BarLineType;
 export '/src/measure/measure.dart' show Measure;
 export '/src/music_objects/clef/clef.dart' show Clef;
+export '/src/music_objects/clef/clef_type.dart' show ClefType;
 export '/src/simple_sheet_music.dart' show SimpleSheetMusic;
 export 'src/music_objects/key_signature/key_signature.dart' show KeySignature;
+export 'src/music_objects/key_signature/keysignature_type.dart' show KeySignatureType;
 export 'src/music_objects/notes/accidental.dart' show Accidental;
 export 'src/music_objects/notes/chord_note/chord_note.dart' show ChordNote;
 export 'src/music_objects/notes/chord_note/chord_note_part.dart'

--- a/lib/src/measure/bar_line_type.dart
+++ b/lib/src/measure/bar_line_type.dart
@@ -1,0 +1,14 @@
+/// The type of bar line to draw at the end of a measure.
+enum BarLineType {
+  /// No bar line.
+  none,
+
+  /// A single thin bar line (default).
+  single,
+
+  /// Two thin bar lines side by side.
+  double_,
+
+  /// A thin bar line followed by a thick bar line (final bar).
+  final_,
+}

--- a/lib/src/measure/measure.dart
+++ b/lib/src/measure/measure.dart
@@ -2,6 +2,7 @@ import 'dart:core';
 
 import 'package:simple_sheet_music/src/glyph_metadata.dart';
 import 'package:simple_sheet_music/src/glyph_path.dart';
+import 'package:simple_sheet_music/src/measure/bar_line_type.dart';
 import 'package:simple_sheet_music/src/music_objects/clef/clef.dart';
 import 'package:simple_sheet_music/src/music_objects/clef/clef_type.dart';
 import 'package:simple_sheet_music/src/music_objects/interface/musical_symbol.dart';
@@ -17,11 +18,13 @@ class Measure {
   ///
   /// The [musicalSymbols] parameter is a list of musical symbols that make up the measure.
   /// The [isNewLine] parameter indicates whether the measure is a new line in the sheet music.
+  /// The [barLine] parameter controls the bar line drawn at the end of this measure.
   ///
   /// Throws an [AssertionError] if the [musicalSymbols] list is empty.
   const Measure(
     this.musicalSymbols, {
     this.isNewLine = false,
+    this.barLine = BarLineType.single,
   }) : assert(musicalSymbols.length != 0);
 
   /// The list of musical symbols that make up the measure.
@@ -29,6 +32,9 @@ class Measure {
 
   /// Indicates whether the measure is a new line in the sheet music.
   final bool isNewLine;
+
+  /// The type of bar line to draw at the end of this measure.
+  final BarLineType barLine;
 
   /// Sets the context for the measure and returns a list of musical symbol metrics.
   ///

--- a/lib/src/measure/measure_metrics.dart
+++ b/lib/src/measure/measure_metrics.dart
@@ -2,6 +2,7 @@ import 'dart:math';
 
 import 'package:simple_sheet_music/src/extension/list_extension.dart';
 import 'package:simple_sheet_music/src/glyph_metadata.dart';
+import 'package:simple_sheet_music/src/measure/bar_line_type.dart';
 import 'package:simple_sheet_music/src/measure/measure_renderer.dart';
 import 'package:simple_sheet_music/src/music_objects/interface/musical_symbol_metrics.dart';
 import 'package:simple_sheet_music/src/music_objects/interface/musical_symbol_renderer.dart';
@@ -16,10 +17,12 @@ class MeasureMetrics {
   /// for the measure.
   ///
   /// The [isNewLine] parameter indicates whether a line break should occur in this measure.
+  /// The [barLine] parameter controls the bar line drawn at the end of this measure.
   const MeasureMetrics(
     this.musicalSymbolsMetricses,
     this.metadata, {
     required this.isNewLine,
+    this.barLine = BarLineType.single,
   });
 
   /// The list of [MusicalSymbolMetrics] representing the metrics of each musical
@@ -31,6 +34,9 @@ class MeasureMetrics {
 
   /// Indicates whether a line break should occur in this measure.
   final bool isNewLine;
+
+  /// The type of bar line to draw at the end of this measure.
+  final BarLineType barLine;
 
   /// Gets the total width of all the musical symbols in the measure.
   double get objectsWidth =>
@@ -86,6 +92,7 @@ class MeasureMetrics {
         layout,
         measureOriginX: measureInitialX,
         staffLineCenterY: staffLineCenterY,
+        barLine: barLine,
       );
 
   List<MusicalSymbolRenderer> _symbolRenderers(

--- a/lib/src/measure/measure_renderer.dart
+++ b/lib/src/measure/measure_renderer.dart
@@ -2,6 +2,7 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:simple_sheet_music/src/constants.dart';
+import 'package:simple_sheet_music/src/measure/bar_line_type.dart';
 import 'package:simple_sheet_music/src/measure/measure_metrics.dart';
 import 'package:simple_sheet_music/src/music_objects/interface/musical_symbol_renderer.dart';
 import 'package:simple_sheet_music/src/sheet_music_layout.dart';
@@ -14,12 +15,14 @@ class MeasureRenderer {
     this.layout, {
     required this.measureOriginX,
     required this.staffLineCenterY,
+    this.barLine = BarLineType.single,
   });
 
   final List<MusicalSymbolRenderer> symbolRenderers;
   final MeasureMetrics measureMetrics;
   final double measureOriginX;
   final double staffLineCenterY;
+  final BarLineType barLine;
 
   /// Performs a hit test at the given [position] and returns the corresponding [MusicalSymbolRenderer].
   ///
@@ -39,6 +42,7 @@ class MeasureRenderer {
     for (final symbol in symbolRenderers) {
       symbol.render(canvas);
     }
+    _renderBarLine(canvas);
   }
 
   void _renderStaffLine(Canvas canvas) {
@@ -58,6 +62,41 @@ class MeasureRenderer {
           ..color = layout.lineColor
           ..strokeWidth = measureMetrics.staffLineThickness,
       );
+    }
+  }
+
+  void _renderBarLine(Canvas canvas) {
+    if (barLine == BarLineType.none) return;
+
+    final top    = staffLineCenterY - Constants.staffSpace * 2;
+    final bottom = staffLineCenterY + Constants.staffSpace * 2;
+    final x      = measureOriginX + width;
+    final thick  = measureMetrics.staffLineThickness;
+
+    final thinPaint = Paint()
+      ..color = layout.lineColor
+      ..strokeWidth = thick;
+
+    final thickPaint = Paint()
+      ..color = layout.lineColor
+      ..strokeWidth = thick * 4;
+
+    switch (barLine) {
+      case BarLineType.none:
+        break;
+      case BarLineType.single:
+        canvas.drawLine(Offset(x, top), Offset(x, bottom), thinPaint);
+        break;
+      case BarLineType.double_:
+        final gap = Constants.staffSpace * 0.18;
+        canvas.drawLine(Offset(x - gap, top), Offset(x - gap, bottom), thinPaint);
+        canvas.drawLine(Offset(x, top), Offset(x, bottom), thinPaint);
+        break;
+      case BarLineType.final_:
+        final gap = Constants.staffSpace * 0.25;
+        canvas.drawLine(Offset(x - gap - thick * 2, top), Offset(x - gap - thick * 2, bottom), thinPaint);
+        canvas.drawLine(Offset(x, top), Offset(x, bottom), thickPaint);
+        break;
     }
   }
 

--- a/lib/src/sheet_music_metrics.dart
+++ b/lib/src/sheet_music_metrics.dart
@@ -35,8 +35,12 @@ class SheetMusicMetrics {
         paths,
       );
       context = measure.updateContext(context);
-      final measureMetrics =
-          MeasureMetrics(symbols, metadata, isNewLine: measure.isNewLine);
+      final measureMetrics = MeasureMetrics(
+        symbols,
+        metadata,
+        isNewLine: measure.isNewLine,
+        barLine: measure.barLine,
+      );
       result.add(measureMetrics);
     }
 


### PR DESCRIPTION
  Add BarLineType enum with four variants: none, single, double_, final_.

  - Measure accepts a new `barLine` parameter (default: BarLineType.single)
  - MeasureMetrics carries the value through to MeasureRenderer
  - MeasureRenderer draws the bar line at the right edge of each measure after rendering staff lines and symbols