### PR TITLE
Add CD workflow for pub.dev publishing

### DIFF
--- a/.github/workflows/publish_to_pub_dev.yml
+++ b/.github/workflows/publish_to_pub_dev.yml
@@ -1,0 +1,57 @@
+name: Publish to pub.dev
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-24.04-slim
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.24.3"
+          channel: 'stable'
+          cache: true
+
+      - name: Cache pub dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.pub-cache
+            .dart_tool
+          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pub-
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Run tests
+        run: flutter test
+
+      - name: Verify version matches tag
+        run: |
+          TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          PUBSPEC_VERSION=$(grep '^version:' pubspec.yaml | cut -d ' ' -f 2)
+          if [ "$TAG_VERSION" != "$PUBSPEC_VERSION" ]; then
+            echo "Error: Tag version ($TAG_VERSION) does not match pubspec.yaml version ($PUBSPEC_VERSION)"
+            exit 1
+          fi
+
+      - name: Setup pub credentials
+        run: |
+          mkdir -p $HOME/.config/dart
+          echo '${{ secrets.PUB_CREDENTIALS }}' > $HOME/.config/dart/pub-credentials.json
+
+      - name: Dry run
+        run: flutter pub publish --dry-run
+
+      - name: Publish to pub.dev
+        run: flutter pub publish --force


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to automatically publish to pub.dev on tag push (`v*`)
- Run tests and dry-run validation before publishing
- Verify tag version matches pubspec.yaml version
- Cache Flutter SDK and pub dependencies for faster builds

## Setup Required
1. Run `dart pub login` locally to get credentials
2. Add `PUB_CREDENTIALS` secret in repository settings with the content of `~/.config/dart/pub-credentials.json`

## Usage
```bash
# 1. Update version in pubspec.yaml
# 2. Commit and push
git add pubspec.yaml
git commit -m "Bump version to x.x.x"
git push origin main

# 3. Create and push tag
git tag vx.x.x
git push origin vx.x.x
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)