### PR TITLE
Improve VRT workflow for PR-based visual diff detection

### DIFF
--- a/.github/workflows/unit_tests_run.yml
+++ b/.github/workflows/unit_tests_run.yml
@@ -32,7 +32,7 @@ jobs:
         run: flutter pub get
         
       - name: library unit tests
-        run: flutter test
+        run: flutter test --exclude-tags=golden
 
       # - name: example unit tests
       #   working-directory: example

--- a/.github/workflows/vrt-baseline.yml
+++ b/.github/workflows/vrt-baseline.yml
@@ -1,0 +1,38 @@
+name: Update VRT Baseline
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'lib/**'
+      - 'test/golden_test/**'
+  workflow_dispatch:
+
+jobs:
+  update-baseline:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.32.0"
+          channel: stable
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Generate Golden Images
+        run: flutter test --tags=golden --update-goldens
+        env:
+          CI: true
+
+      - name: Upload Baseline
+        uses: actions/upload-artifact@v4
+        with:
+          name: vrt-baseline
+          path: test/golden_test/goldens/ci/
+          retention-days: 90

--- a/.github/workflows/vrt-check.yml
+++ b/.github/workflows/vrt-check.yml
@@ -1,15 +1,16 @@
-name: Visual Regression Test
+name: VRT Check
 
 on:
-  push:
-    tags:
-      - 'v*'  # リリースタグ作成時のみ実行
-  workflow_dispatch:  # 手動実行も可能
+  pull_request:
+    branches: [main]
+    paths:
+      - 'lib/**'
+      - 'test/golden_test/**'
 
 jobs:
-  golden-test:
+  check-visual-diff:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -23,17 +24,23 @@ jobs:
       - name: Install dependencies
         run: flutter pub get
 
+      - name: Download Baseline
+        uses: dawidd6/action-download-artifact@v6
+        with:
+          workflow: vrt-baseline.yml
+          branch: main
+          name: vrt-baseline
+          path: test/golden_test/goldens/ci/
+
       - name: Run Golden Tests
         run: flutter test --tags=golden
         env:
           CI: true
 
-      - name: Upload Golden Failures
+      - name: Upload Diff Images
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: golden-failures
-          path: |
-            test/failures/
-            test/golden_test/goldens/
+          name: vrt-diff
+          path: test/golden_test/failures/
           retention-days: 7


### PR DESCRIPTION
## Summary
- VRTワークフローをPRベースの差分検出に改善
- `vrt-baseline.yml`: mainへのpush時にベースラインを生成・アーティファクトとして保存
- `vrt-check.yml`: PRでベースラインをダウンロードし、視覚的な差分を検出
- `unit_tests_run.yml`: ゴールデンテストを除外（VRT専用ワークフローに分離）

## 変更内容
| ファイル | 変更 |
|---------|------|
| `vrt-baseline.yml` | 新規追加: mainへのpush時にCI用ゴールデン画像を生成 |
| `vrt-check.yml` | `vrt.yml`からリネーム: PRトリガーに変更、ベースラインダウンロード追加 |
| `unit_tests_run.yml` | `--exclude-tags=golden` を追加 |

## Test plan
- [ ] mainへのマージ後、`vrt-baseline.yml` が実行されベースラインが生成されることを確認
- [ ] 別ブランチからのPRで `vrt-check.yml` が実行されることを確認
- [ ] 意図的な視覚変更を含むPRで差分が検出されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)