### PR TITLE
refactor: Remove MusicalSymbol implementation from Measure and Staff

### DIFF
--- a/catalog/lib/glyph_row.dart
+++ b/catalog/lib/glyph_row.dart
@@ -54,7 +54,7 @@ class GlyphRow extends StatelessWidget {
                 SizedBox(
                   height: 80,
                   child: SimpleSheetMusic(
-                    musicalSymbols: [bravuraMeasure],
+                    staffs: [Staff([bravuraMeasure])],
                     height: 80,
                     width: 120,
                   ),
@@ -72,7 +72,7 @@ class GlyphRow extends StatelessWidget {
                 SizedBox(
                   height: 80,
                   child: SimpleSheetMusic(
-                    musicalSymbols: [petalumaMeasure],
+                    staffs: [Staff([petalumaMeasure])],
                     fontType: FontType.petaluma,
                     height: 80,
                     width: 120,

--- a/catalog/lib/scale_catalog_page.dart
+++ b/catalog/lib/scale_catalog_page.dart
@@ -1,0 +1,330 @@
+import 'package:flutter/material.dart';
+import 'package:simple_sheet_music/simple_sheet_music.dart';
+
+import 'scale_row.dart';
+
+/// 表示モード
+enum DisplayMode {
+  naturalNotes,
+  chromatic,
+  durations,
+}
+
+extension DisplayModeExtension on DisplayMode {
+  String get label {
+    switch (this) {
+      case DisplayMode.naturalNotes:
+        return 'Natural Notes';
+      case DisplayMode.chromatic:
+        return 'Chromatic';
+      case DisplayMode.durations:
+        return 'Durations';
+    }
+  }
+}
+
+/// Clefタイプと対応するClefオブジェクトを生成する関数
+enum ClefSelection {
+  treble,
+  bass,
+  alto,
+  tenor,
+}
+
+extension ClefSelectionExtension on ClefSelection {
+  String get label {
+    switch (this) {
+      case ClefSelection.treble:
+        return 'Treble';
+      case ClefSelection.bass:
+        return 'Bass';
+      case ClefSelection.alto:
+        return 'Alto';
+      case ClefSelection.tenor:
+        return 'Tenor';
+    }
+  }
+
+  Clef createClef() {
+    switch (this) {
+      case ClefSelection.treble:
+        return const Clef.treble();
+      case ClefSelection.bass:
+        return const Clef.bass();
+      case ClefSelection.alto:
+        return const Clef.alto();
+      case ClefSelection.tenor:
+        return const Clef.tenor();
+    }
+  }
+}
+
+/// オクターブごとの自然音ピッチ
+const Map<int, List<Pitch>> naturalNotesByOctave = {
+  0: [Pitch.a0, Pitch.b0],
+  1: [Pitch.c1, Pitch.d1, Pitch.e1, Pitch.f1, Pitch.g1, Pitch.a1, Pitch.b1],
+  2: [Pitch.c2, Pitch.d2, Pitch.e2, Pitch.f2, Pitch.g2, Pitch.a2, Pitch.b2],
+  3: [Pitch.c3, Pitch.d3, Pitch.e3, Pitch.f3, Pitch.g3, Pitch.a3, Pitch.b3],
+  4: [Pitch.c4, Pitch.d4, Pitch.e4, Pitch.f4, Pitch.g4, Pitch.a4, Pitch.b4],
+  5: [Pitch.c5, Pitch.d5, Pitch.e5, Pitch.f5, Pitch.g5, Pitch.a5, Pitch.b5],
+  6: [Pitch.c6, Pitch.d6, Pitch.e6, Pitch.f6, Pitch.g6, Pitch.a6, Pitch.b6],
+  7: [Pitch.c7, Pitch.d7, Pitch.e7, Pitch.f7, Pitch.g7, Pitch.a7, Pitch.b7],
+  8: [Pitch.c8],
+};
+
+/// 比較表示用の音符の長さ
+const List<NoteDuration> comparisonDurations = [
+  NoteDuration.whole,
+  NoteDuration.half,
+  NoteDuration.quarter,
+  NoteDuration.eighth,
+];
+
+class ScaleCatalogPage extends StatefulWidget {
+  const ScaleCatalogPage({super.key});
+
+  @override
+  State<ScaleCatalogPage> createState() => _ScaleCatalogPageState();
+}
+
+class _ScaleCatalogPageState extends State<ScaleCatalogPage>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+  DisplayMode _displayMode = DisplayMode.naturalNotes;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController =
+        TabController(length: ClefSelection.values.length, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        // Clef選択タブ
+        TabBar(
+          controller: _tabController,
+          tabs: ClefSelection.values.map((c) => Tab(text: c.label)).toList(),
+          labelColor: Theme.of(context).colorScheme.primary,
+          unselectedLabelColor: Colors.grey,
+          onTap: (_) => setState(() {}),
+        ),
+        // 表示モード選択
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          child: SegmentedButton<DisplayMode>(
+            segments: DisplayMode.values
+                .map((m) => ButtonSegment(value: m, label: Text(m.label)))
+                .toList(),
+            selected: {_displayMode},
+            onSelectionChanged: (selected) {
+              setState(() {
+                _displayMode = selected.first;
+              });
+            },
+          ),
+        ),
+        // コンテンツ
+        Expanded(
+          child: TabBarView(
+            controller: _tabController,
+            children: ClefSelection.values.map(_buildContent).toList(),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildContent(ClefSelection clefSelection) {
+    switch (_displayMode) {
+      case DisplayMode.naturalNotes:
+        return _buildNaturalNotesView(clefSelection);
+      case DisplayMode.chromatic:
+        return _buildChromaticView(clefSelection);
+      case DisplayMode.durations:
+        return _buildDurationsView(clefSelection);
+    }
+  }
+
+  Widget _buildNaturalNotesView(ClefSelection clefSelection) {
+    final octaves = naturalNotesByOctave.keys.toList()..sort();
+    return ListView.builder(
+      itemCount: octaves.length,
+      itemBuilder: (context, index) {
+        final octave = octaves[index];
+        final pitches = naturalNotesByOctave[octave]!;
+        return ScaleRow(
+          octave: octave,
+          pitches: pitches,
+          clef: clefSelection.createClef(),
+        );
+      },
+    );
+  }
+
+  Widget _buildChromaticView(ClefSelection clefSelection) {
+    // 半音階表示：各オクターブで12音（臨時記号付き）
+    final octaves = [1, 2, 3, 4, 5, 6, 7];
+    return ListView.builder(
+      itemCount: octaves.length,
+      itemBuilder: (context, index) {
+        final octave = octaves[index];
+        return _ChromaticRow(
+          octave: octave,
+          clef: clefSelection.createClef(),
+        );
+      },
+    );
+  }
+
+  Widget _buildDurationsView(ClefSelection clefSelection) {
+    // 代表的なピッチで音符の長さを比較
+    final representativePitches = [
+      Pitch.c4,
+      Pitch.g4,
+      Pitch.c5,
+      Pitch.g5,
+    ];
+    return ListView.builder(
+      itemCount: representativePitches.length,
+      itemBuilder: (context, index) {
+        final pitch = representativePitches[index];
+        return _DurationComparisonRow(
+          pitch: pitch,
+          clef: clefSelection.createClef(),
+        );
+      },
+    );
+  }
+}
+
+/// 半音階表示用の行ウィジェット
+class _ChromaticRow extends StatelessWidget {
+  const _ChromaticRow({
+    required this.octave,
+    required this.clef,
+  });
+
+  final int octave;
+  final Clef clef;
+
+  @override
+  Widget build(BuildContext context) {
+    final pitches = naturalNotesByOctave[octave]!;
+
+    // 半音階のノートを生成（自然音 + シャープ）
+    final chromaticNotes = <Note>[];
+    for (final pitch in pitches) {
+      // 自然音
+      chromaticNotes.add(Note(pitch));
+      // C, D, F, G, A にはシャープを追加
+      final pitchName = pitch.name;
+      if (pitchName.startsWith('c') ||
+          pitchName.startsWith('d') ||
+          pitchName.startsWith('f') ||
+          pitchName.startsWith('g') ||
+          pitchName.startsWith('a')) {
+        chromaticNotes.add(Note(
+          pitch,
+          accidental: Accidental.sharp,
+        ));
+      }
+    }
+
+    // 音符数に応じた幅を計算
+    final sheetWidth = 100.0 + (chromaticNotes.length * 50.0);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+      decoration: BoxDecoration(
+        border: Border(bottom: BorderSide(color: Colors.grey.shade300)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Octave $octave (Chromatic)',
+            style: const TextStyle(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: 8),
+          SizedBox(
+            height: 120,
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: SimpleSheetMusic(
+                staffs: [
+                  Staff([Measure([clef, ...chromaticNotes])]),
+                ],
+                height: 120,
+                width: sheetWidth,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// 音符の長さ比較用の行ウィジェット
+class _DurationComparisonRow extends StatelessWidget {
+  const _DurationComparisonRow({
+    required this.pitch,
+    required this.clef,
+  });
+
+  final Pitch pitch;
+  final Clef clef;
+
+  @override
+  Widget build(BuildContext context) {
+    final notes = comparisonDurations
+        .map((duration) => Note(pitch, noteDuration: duration))
+        .toList();
+
+    // 音符数に応じた幅を計算
+    final sheetWidth = 100.0 + (notes.length * 80.0);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+      decoration: BoxDecoration(
+        border: Border(bottom: BorderSide(color: Colors.grey.shade300)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            '${pitch.name.toUpperCase()} - Duration Comparison',
+            style: const TextStyle(fontWeight: FontWeight.bold),
+          ),
+          Text(
+            'whole, half, quarter, eighth',
+            style: TextStyle(fontSize: 12, color: Colors.grey.shade600),
+          ),
+          const SizedBox(height: 8),
+          SizedBox(
+            height: 120,
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: SimpleSheetMusic(
+                staffs: [
+                  Staff([Measure([clef, ...notes])]),
+                ],
+                height: 120,
+                width: sheetWidth,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/catalog/lib/scale_row.dart
+++ b/catalog/lib/scale_row.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:simple_sheet_music/simple_sheet_music.dart';
+
+/// 1オクターブ分の自然音を表示する行ウィジェット
+class ScaleRow extends StatelessWidget {
+  const ScaleRow({
+    super.key,
+    required this.octave,
+    required this.pitches,
+    required this.clef,
+  });
+
+  final int octave;
+  final List<Pitch> pitches;
+  final Clef clef;
+
+  @override
+  Widget build(BuildContext context) {
+    final notes = pitches.map(Note.new).toList();
+
+    final pitchRange = pitches.length == 1
+        ? pitches.first.name.toUpperCase()
+        : '${pitches.first.name.toUpperCase()}-${pitches.last.name.toUpperCase()}';
+
+    // 音符数に応じた幅を計算（1音符あたり約50px + clef分100px）
+    final sheetWidth = 100.0 + (notes.length * 50.0);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+      decoration: BoxDecoration(
+        border: Border(bottom: BorderSide(color: Colors.grey.shade300)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Text(
+                'Octave $octave',
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                '($pitchRange)',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Colors.grey.shade600,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          SizedBox(
+            height: 120,
+            child: SingleChildScrollView(
+              scrollDirection: Axis.horizontal,
+              child: SimpleSheetMusic(
+                staffs: [
+                  Staff([Measure([clef, ...notes])]),
+                ],
+                height: 120,
+                width: sheetWidth,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -90,7 +90,7 @@ class SimpleSheetMusicDemoState extends State {
             child: SimpleSheetMusic(
               height: height,
               width: width,
-              musicalSymbols: [measure1, measure2, measure3],
+              staffs: [Staff([measure1, measure2, measure3])],
             ),
           ),
         ));

--- a/lib/src/measure/measure.dart
+++ b/lib/src/measure/measure.dart
@@ -10,6 +10,7 @@ import 'package:simple_sheet_music/src/music_objects/clef/clef.dart';
 import 'package:simple_sheet_music/src/music_objects/clef/clef_type.dart';
 import 'package:simple_sheet_music/src/music_objects/interface/musical_symbol.dart';
 import 'package:simple_sheet_music/src/music_objects/interface/musical_symbol_renderer.dart';
+import 'package:simple_sheet_music/src/music_objects/interface/sheet_music_element.dart';
 import 'package:simple_sheet_music/src/music_objects/key_signature/key_signature.dart';
 import 'package:simple_sheet_music/src/music_objects/key_signature/keysignature_type.dart';
 import 'package:simple_sheet_music/src/music_objects/time_signature/time_signature.dart';
@@ -17,7 +18,7 @@ import 'package:simple_sheet_music/src/music_objects/time_signature/time_signatu
 import 'package:simple_sheet_music/src/musical_context.dart';
 
 /// Represents a measure in sheet music.
-class Measure implements MusicalSymbol {
+class Measure extends SheetMusicElement {
   /// Creates a new instance of the [Measure] class.
   ///
   /// The [musicalSymbols] parameter is a list of musical symbols that make up the measure.
@@ -41,10 +42,8 @@ class Measure implements MusicalSymbol {
   /// Indicates whether the measure is a new line in the sheet music.
   final bool isNewLine;
 
-  @override
   final Color color;
 
-  @override
   final EdgeInsets margin;
 
   /// The barline type at the start of the measure.
@@ -62,7 +61,6 @@ class Measure implements MusicalSymbol {
   /// The [paths] parameter provides the paths for the glyphs used in the measure.
   ///
   /// Returns a [MeasureRenderer] object representing the renderer for this measure.
-  @override
   MeasureRenderer setContext(
     MusicalContext context,
     GlyphMetadata metadata,

--- a/lib/src/measure/measure_renderer.dart
+++ b/lib/src/measure/measure_renderer.dart
@@ -10,7 +10,7 @@ import 'package:simple_sheet_music/src/sheet_music_layout.dart';
 
 /// The renderer for a measure in sheet music.
 /// Combines metrics calculation and rendering functionality.
-class MeasureRenderer implements MusicalSymbolRenderer {
+class MeasureRenderer {
   const MeasureRenderer(
     this.symbolRenderers,
     this.metadata, {
@@ -44,7 +44,6 @@ class MeasureRenderer implements MusicalSymbolRenderer {
   double get _measureUpperHeight => metadata.measureUpperHeight;
 
   /// Returns the maximum height of the measure upper part.
-  @override
   double get upperHeight => max(_symbolMaximumUpperHeight, _measureUpperHeight);
 
   /// Gets the maximum lower height among all the musical symbols in the measure.
@@ -55,7 +54,6 @@ class MeasureRenderer implements MusicalSymbolRenderer {
   double get _measureLowerHeight => metadata.measureLowerHeight;
 
   /// Returns the maximum height of the measure lower part.
-  @override
   double get lowerHeight => max(_symbolMaximumLowerHeight, _measureLowerHeight);
 
   /// Gets the sum of the horizontal margins of all the musical symbols in the measure.
@@ -65,10 +63,8 @@ class MeasureRenderer implements MusicalSymbolRenderer {
   /// Gets the thickness of the staff lines in the measure.
   double get staffLineThickness => metadata.staffLineThickness;
 
-  @override
   double get width => objectsWidth;
 
-  @override
   EdgeInsets get margin => measure.margin;
 
   // Rendering methods
@@ -99,7 +95,6 @@ class MeasureRenderer implements MusicalSymbolRenderer {
     return null;
   }
 
-  @override
   bool isHit(
     Offset position, {
     required SheetMusicLayout layout,
@@ -115,7 +110,6 @@ class MeasureRenderer implements MusicalSymbolRenderer {
         null;
   }
 
-  @override
   void render(
     Canvas canvas, {
     required SheetMusicLayout layout,

--- a/lib/src/music_objects/interface/musical_symbol.dart
+++ b/lib/src/music_objects/interface/musical_symbol.dart
@@ -2,6 +2,7 @@ import 'package:flutter/rendering.dart';
 import 'package:simple_sheet_music/src/glyph_metadata.dart';
 import 'package:simple_sheet_music/src/glyph_path.dart';
 import 'package:simple_sheet_music/src/music_objects/interface/musical_symbol_renderer.dart';
+import 'package:simple_sheet_music/src/music_objects/interface/sheet_music_element.dart';
 import 'package:simple_sheet_music/src/musical_context.dart';
 
 /// An abstract class representing a musical symbol.
@@ -9,7 +10,7 @@ import 'package:simple_sheet_music/src/musical_context.dart';
 /// This class serves as the base class for all musical symbols in the
 /// application. It provides common properties and methods that are shared
 /// among different types of musical symbols.
-abstract class MusicalSymbol {
+abstract class MusicalSymbol extends SheetMusicElement {
   /// Creates a new instance of the [MusicalSymbol] class.
   ///
   /// The [margin] parameter specifies the margin around the musical symbol.

--- a/lib/src/music_objects/interface/sheet_music_element.dart
+++ b/lib/src/music_objects/interface/sheet_music_element.dart
@@ -1,0 +1,7 @@
+/// Base class for any element that can be rendered in sheet music.
+///
+/// This includes both `MusicalSymbol` (atomic notation elements like notes, clefs)
+/// and structural containers like `Measure` and `Staff`.
+abstract class SheetMusicElement {
+  const SheetMusicElement();
+}

--- a/lib/src/sheet_music_metrics.dart
+++ b/lib/src/sheet_music_metrics.dart
@@ -1,10 +1,8 @@
 import 'package:simple_sheet_music/src/extension/list_extension.dart';
 import 'package:simple_sheet_music/src/glyph_metadata.dart';
 import 'package:simple_sheet_music/src/glyph_path.dart';
-import 'package:simple_sheet_music/src/measure/measure.dart';
 import 'package:simple_sheet_music/src/measure/measure_renderer.dart';
 import 'package:simple_sheet_music/src/music_objects/clef/clef_type.dart';
-import 'package:simple_sheet_music/src/music_objects/interface/musical_symbol.dart';
 import 'package:simple_sheet_music/src/music_objects/key_signature/keysignature_type.dart';
 import 'package:simple_sheet_music/src/music_objects/time_signature/time_signature_type.dart';
 import 'package:simple_sheet_music/src/musical_context.dart';
@@ -14,7 +12,7 @@ import 'package:simple_sheet_music/src/staff/staff_renderer.dart';
 /// Represents the metrics of a sheet music.
 class SheetMusicMetrics {
   SheetMusicMetrics(
-    this.musicalSymbols,
+    this.staffs,
     this.initialClefType,
     this.initialKeySignatureType,
     this.initialTimeSignatureType,
@@ -25,7 +23,6 @@ class SheetMusicMetrics {
   List<MeasureRenderer>? _measureRenderersCache;
 
   /// Gets the renderers of each measure in the sheet music.
-  /// Handles both Measure and Staff inputs.
   List<MeasureRenderer> get _measureRenderers {
     if (_measureRenderersCache != null) {
       return _measureRenderersCache!;
@@ -37,18 +34,11 @@ class SheetMusicMetrics {
       initialTimeSignatureType,
     );
 
-    for (final symbol in musicalSymbols) {
-      if (symbol is Measure) {
-        final measureRenderer = symbol.setContext(context, metadata, paths);
-        context = symbol.updateContext(context);
+    for (final staff in staffs) {
+      for (final measure in staff.measures) {
+        final measureRenderer = measure.setContext(context, metadata, paths);
+        context = measure.updateContext(context);
         result.add(measureRenderer);
-      } else if (symbol is Staff) {
-        // Staff contains multiple measures
-        for (final measure in symbol.measures) {
-          final measureRenderer = measure.setContext(context, metadata, paths);
-          context = measure.updateContext(context);
-          result.add(measureRenderer);
-        }
       }
     }
 
@@ -78,7 +68,7 @@ class SheetMusicMetrics {
     return _staffRenderersCache ??= staffs;
   }
 
-  final List<MusicalSymbol> musicalSymbols;
+  final List<Staff> staffs;
   final ClefType initialClefType;
   final KeySignatureType initialKeySignatureType;
   final TimeSignatureType? initialTimeSignatureType;

--- a/lib/src/simple_sheet_music.dart
+++ b/lib/src/simple_sheet_music.dart
@@ -7,23 +7,23 @@ import 'package:simple_sheet_music/src/music_objects/clef/clef_type.dart';
 import 'package:simple_sheet_music/src/music_objects/time_signature/time_signature_type.dart';
 import 'package:simple_sheet_music/src/sheet_music_metrics.dart';
 import 'package:simple_sheet_music/src/sheet_music_renderer.dart';
+import 'package:simple_sheet_music/src/staff/staff.dart';
 
 import 'font_types.dart';
-import 'music_objects/interface/musical_symbol.dart';
 import 'music_objects/key_signature/keysignature_type.dart';
 import 'sheet_music_layout.dart';
 
 typedef OnTapMusicObjectCallback = void Function(
-  MusicalSymbol musicObject,
+  Staff staff,
   Offset offset,
 );
 
 /// The `SimpleSheetMusic` widget is used to display sheet music.
-/// It takes a list of `MusicalSymbol` objects (Measure, Staff, etc.), an initial clef, and other optional parameters to customize the appearance of the sheet music.
+/// It takes a list of `Staff` objects, an initial clef, and other optional parameters to customize the appearance of the sheet music.
 class SimpleSheetMusic extends StatelessWidget {
   const SimpleSheetMusic({
     super.key,
-    required this.musicalSymbols,
+    required this.staffs,
     this.initialClefType = ClefType.treble,
     this.initialKeySignatureType = KeySignatureType.cMajor,
     this.initialTimeSignatureType,
@@ -33,8 +33,8 @@ class SimpleSheetMusic extends StatelessWidget {
     this.fontType = FontType.bravura,
   });
 
-  /// The list of musical symbols to be displayed (Measure, Staff, etc.).
-  final List<MusicalSymbol> musicalSymbols;
+  /// The list of staffs to be displayed.
+  final List<Staff> staffs;
 
   /// Receive maximum width and height so as not to break the aspect ratio of the score.
   final double height;
@@ -63,7 +63,7 @@ class SimpleSheetMusic extends StatelessWidget {
     final metadata = GlyphMetadata(fontType.metadataData);
     final targetSize = Size(width, height);
     final metricsBuilder = SheetMusicMetrics(
-      musicalSymbols,
+      staffs,
       initialClefType,
       initialKeySignatureType,
       initialTimeSignatureType,

--- a/lib/src/staff/staff.dart
+++ b/lib/src/staff/staff.dart
@@ -2,13 +2,12 @@ import 'package:flutter/material.dart';
 import 'package:simple_sheet_music/src/glyph_metadata.dart';
 import 'package:simple_sheet_music/src/glyph_path.dart';
 import 'package:simple_sheet_music/src/measure/measure.dart';
-import 'package:simple_sheet_music/src/music_objects/interface/musical_symbol.dart';
-import 'package:simple_sheet_music/src/music_objects/interface/musical_symbol_renderer.dart';
+import 'package:simple_sheet_music/src/music_objects/interface/sheet_music_element.dart';
 import 'package:simple_sheet_music/src/musical_context.dart';
 import 'package:simple_sheet_music/src/staff/staff_renderer.dart';
 
 /// Represents a staff in sheet music, containing multiple measures.
-class Staff implements MusicalSymbol {
+class Staff extends SheetMusicElement {
   /// Creates a new instance of the [Staff] class.
   ///
   /// The [measures] parameter is a list of measures that make up the staff.
@@ -21,10 +20,8 @@ class Staff implements MusicalSymbol {
   /// The list of measures that make up the staff.
   final List<Measure> measures;
 
-  @override
   final Color color;
 
-  @override
   final EdgeInsets margin;
 
   /// Sets the context for the staff and returns a StaffRenderer.
@@ -34,8 +31,7 @@ class Staff implements MusicalSymbol {
   /// The [paths] parameter provides the paths for the glyphs used in the staff.
   ///
   /// Returns a [StaffRenderer] object representing the renderer for this staff.
-  @override
-  MusicalSymbolRenderer setContext(
+  StaffRenderer setContext(
     MusicalContext context,
     GlyphMetadata metadata,
     GlyphPaths paths,

--- a/lib/src/staff/staff_renderer.dart
+++ b/lib/src/staff/staff_renderer.dart
@@ -7,7 +7,7 @@ import 'package:simple_sheet_music/src/staff/staff.dart';
 
 /// The renderer for a staff, which is responsible for rendering measures,
 /// handling hit tests, and providing metrics.
-class StaffRenderer implements MusicalSymbolRenderer {
+class StaffRenderer {
   const StaffRenderer(this.measureRenderers, {this.staff});
 
   final List<MeasureRenderer> measureRenderers;
@@ -18,17 +18,14 @@ class StaffRenderer implements MusicalSymbolRenderer {
   // Metrics properties
 
   /// The height of the upper part of the staff.
-  @override
   double get upperHeight =>
       measureRenderers.map((measure) => measure.upperHeight).max;
 
   /// The height of the lower part of the staff.
-  @override
   double get lowerHeight =>
       measureRenderers.map((measure) => measure.lowerHeight).max;
 
   /// The total width of the staff, including the width of its objects and margins.
-  @override
   double get width => _objectsWidth + horizontalMarginSum;
 
   /// The total width of the objects in the staff.
@@ -42,7 +39,6 @@ class StaffRenderer implements MusicalSymbolRenderer {
   /// The total height of the staff.
   double get height => upperHeight + lowerHeight;
 
-  @override
   EdgeInsets get margin => staff?.margin ?? EdgeInsets.zero;
 
   // Rendering methods
@@ -72,7 +68,6 @@ class StaffRenderer implements MusicalSymbolRenderer {
     return null;
   }
 
-  @override
   bool isHit(
     Offset position, {
     required SheetMusicLayout layout,
@@ -88,7 +83,6 @@ class StaffRenderer implements MusicalSymbolRenderer {
         null;
   }
 
-  @override
   void render(
     Canvas canvas, {
     required SheetMusicLayout layout,

--- a/test/golden_test/clef_golden_test.dart
+++ b/test/golden_test/clef_golden_test.dart
@@ -63,8 +63,8 @@ void main() {
 Widget _buildClefWidget(Clef clef) {
   return GoldenTestWrapper(
     child: SimpleSheetMusic(
-      musicalSymbols: [
-        Measure([clef]),
+      staffs: [
+        Staff([Measure([clef])]),
       ],
       height: 150,
       width: 180,

--- a/test/golden_test/key_signature_golden_test.dart
+++ b/test/golden_test/key_signature_golden_test.dart
@@ -98,10 +98,12 @@ void main() {
 Widget _buildKeySignatureWidget(KeySignature keySignature) {
   return GoldenTestWrapper(
     child: SimpleSheetMusic(
-      musicalSymbols: [
-        Measure([
-          const Clef.treble(),
-          keySignature,
+      staffs: [
+        Staff([
+          Measure([
+            const Clef.treble(),
+            keySignature,
+          ]),
         ]),
       ],
       height: 150,
@@ -113,10 +115,12 @@ Widget _buildKeySignatureWidget(KeySignature keySignature) {
 Widget _buildKeySignatureWithClefWidget(KeySignature keySignature, Clef clef) {
   return GoldenTestWrapper(
     child: SimpleSheetMusic(
-      musicalSymbols: [
-        Measure([
-          clef,
-          keySignature,
+      staffs: [
+        Staff([
+          Measure([
+            clef,
+            keySignature,
+          ]),
         ]),
       ],
       height: 150,

--- a/test/golden_test/note_golden_test.dart
+++ b/test/golden_test/note_golden_test.dart
@@ -121,10 +121,12 @@ void main() {
 Widget _buildNoteWidget(NoteDuration duration) {
   return GoldenTestWrapper(
     child: SimpleSheetMusic(
-      musicalSymbols: [
-        Measure([
-          const Clef.treble(),
-          Note(Pitch.b4, noteDuration: duration),
+      staffs: [
+        Staff([
+          Measure([
+            const Clef.treble(),
+            Note(Pitch.b4, noteDuration: duration),
+          ]),
         ]),
       ],
       height: 150,
@@ -136,10 +138,12 @@ Widget _buildNoteWidget(NoteDuration duration) {
 Widget _buildNoteWithAccidentalWidget(Accidental accidental) {
   return GoldenTestWrapper(
     child: SimpleSheetMusic(
-      musicalSymbols: [
-        Measure([
-          const Clef.treble(),
-          Note(Pitch.b4, accidental: accidental),
+      staffs: [
+        Staff([
+          Measure([
+            const Clef.treble(),
+            Note(Pitch.b4, accidental: accidental),
+          ]),
         ]),
       ],
       height: 150,
@@ -151,10 +155,12 @@ Widget _buildNoteWithAccidentalWidget(Accidental accidental) {
 Widget _buildNoteAtPitchWidget(Pitch pitch) {
   return GoldenTestWrapper(
     child: SimpleSheetMusic(
-      musicalSymbols: [
-        Measure([
-          const Clef.treble(),
-          Note(pitch),
+      staffs: [
+        Staff([
+          Measure([
+            const Clef.treble(),
+            Note(pitch),
+          ]),
         ]),
       ],
       height: 150,

--- a/test/golden_test/rest_golden_test.dart
+++ b/test/golden_test/rest_golden_test.dart
@@ -67,10 +67,12 @@ void main() {
 Widget _buildRestWidget(RestType restType) {
   return GoldenTestWrapper(
     child: SimpleSheetMusic(
-      musicalSymbols: [
-        Measure([
-          const Clef.treble(),
-          Rest(restType),
+      staffs: [
+        Staff([
+          Measure([
+            const Clef.treble(),
+            Rest(restType),
+          ]),
         ]),
       ],
       height: 150,

--- a/test/golden_test/time_signature_golden_test.dart
+++ b/test/golden_test/time_signature_golden_test.dart
@@ -182,10 +182,12 @@ void main() {
 Widget _buildMeasureWithTimeSignature(TimeSignature timeSignature) {
   return GoldenTestWrapper(
     child: SimpleSheetMusic(
-      musicalSymbols: [
-        Measure([
-          const Clef.treble(),
-          timeSignature,
+      staffs: [
+        Staff([
+          Measure([
+            const Clef.treble(),
+            timeSignature,
+          ]),
         ]),
       ],
       height: 150,
@@ -197,11 +199,13 @@ Widget _buildMeasureWithTimeSignature(TimeSignature timeSignature) {
 Widget _buildFullMeasure() {
   return GoldenTestWrapper(
     child: SimpleSheetMusic(
-      musicalSymbols: [
-        Measure([
-          const Clef.treble(),
-          const KeySignature.gMajor(),
-          const TimeSignature.fourFour(),
+      staffs: [
+        Staff([
+          Measure([
+            const Clef.treble(),
+            const KeySignature.gMajor(),
+            const TimeSignature.fourFour(),
+          ]),
         ]),
       ],
       height: 150,
@@ -213,11 +217,13 @@ Widget _buildFullMeasure() {
 Widget _buildMeasureWithClefKeyTime() {
   return GoldenTestWrapper(
     child: SimpleSheetMusic(
-      musicalSymbols: [
-        Measure([
-          const Clef.treble(),
-          const KeySignature.dMajor(),
-          const TimeSignature.commonTime(),
+      staffs: [
+        Staff([
+          Measure([
+            const Clef.treble(),
+            const KeySignature.dMajor(),
+            const TimeSignature.commonTime(),
+          ]),
         ]),
       ],
       height: 150,
@@ -229,10 +235,12 @@ Widget _buildMeasureWithClefKeyTime() {
 Widget _buildMeasureWithClefTime() {
   return GoldenTestWrapper(
     child: SimpleSheetMusic(
-      musicalSymbols: [
-        Measure([
-          const Clef.bass(),
-          const TimeSignature.threeFour(),
+      staffs: [
+        Staff([
+          Measure([
+            const Clef.bass(),
+            const TimeSignature.threeFour(),
+          ]),
         ]),
       ],
       height: 150,

--- a/test/sheet_music_metrics_test.dart
+++ b/test/sheet_music_metrics_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:simple_sheet_music/simple_sheet_music.dart';
 import 'package:simple_sheet_music/src/music_objects/clef/clef_type.dart';
 import 'package:simple_sheet_music/src/music_objects/key_signature/keysignature_type.dart';
 import 'package:simple_sheet_music/src/sheet_music_metrics.dart';
@@ -14,7 +15,7 @@ void main() {
       MockMeasure(),
     ];
     final sheetMusicMetrics = SheetMusicMetrics(
-      measures,
+      [Staff(measures)],
       ClefType.treble,
       KeySignatureType.cMajor,
       null,
@@ -39,7 +40,7 @@ void main() {
       MockMeasure(isNewLine: true),
     ];
     final sheetMusicMetrics = SheetMusicMetrics(
-      measures,
+      [Staff(measures)],
       ClefType.treble,
       KeySignatureType.cMajor,
       null,
@@ -65,7 +66,7 @@ void main() {
       MockMeasure(),
     ];
     final sheetMusicMetrics = SheetMusicMetrics(
-      measures,
+      [Staff(measures)],
       ClefType.treble,
       KeySignatureType.cMajor,
       null,


### PR DESCRIPTION
## Summary

- `SheetMusicElement`を新しい基底クラスとして導入し、レンダリング可能な全要素の共通親クラスとする
- `MusicalSymbol`は`SheetMusicElement`を継承（音符、音部記号、休符などの実際の音楽記号用）
- `Measure`と`Staff`は`SheetMusicElement`を直接継承（構造的なコンテナ）
- `MeasureRenderer`と`StaffRenderer`から`MusicalSymbolRenderer`の実装を削除
- `SimpleSheetMusic`と`SheetMusicMetrics`が`List<Staff>`を受け取るように変更し、APIを簡素化・型安全性を向上

この変更により、型階層の意味的な正確性が向上します：
- `MusicalSymbol` = 実際の音楽記号要素
- `Measure`/`Staff` = 構造的なコンテナ

## Test plan

- [x] `dart analyze` - エラーなし
- [x] `flutter test` - 全82テスト合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)