### PR TITLE
refactor: Remove unused code and fix duplicate class definition

### DIFF
--- a/catalog/lib/glyph_row.dart
+++ b/catalog/lib/glyph_row.dart
@@ -54,7 +54,9 @@ class GlyphRow extends StatelessWidget {
                 SizedBox(
                   height: 80,
                   child: SimpleSheetMusic(
-                    staffs: [Staff([bravuraMeasure])],
+                    staffs: [
+                      Staff([bravuraMeasure])
+                    ],
                     height: 80,
                     width: 120,
                   ),
@@ -72,7 +74,9 @@ class GlyphRow extends StatelessWidget {
                 SizedBox(
                   height: 80,
                   child: SimpleSheetMusic(
-                    staffs: [Staff([petalumaMeasure])],
+                    staffs: [
+                      Staff([petalumaMeasure])
+                    ],
                     fontType: FontType.petaluma,
                     height: 80,
                     width: 120,

--- a/catalog/lib/scale_catalog_page.dart
+++ b/catalog/lib/scale_catalog_page.dart
@@ -261,7 +261,9 @@ class _ChromaticRow extends StatelessWidget {
               scrollDirection: Axis.horizontal,
               child: SimpleSheetMusic(
                 staffs: [
-                  Staff([Measure([clef, ...chromaticNotes])]),
+                  Staff([
+                    Measure([clef, ...chromaticNotes])
+                  ]),
                 ],
                 height: 120,
                 width: sheetWidth,
@@ -316,7 +318,9 @@ class _DurationComparisonRow extends StatelessWidget {
               scrollDirection: Axis.horizontal,
               child: SimpleSheetMusic(
                 staffs: [
-                  Staff([Measure([clef, ...notes])]),
+                  Staff([
+                    Measure([clef, ...notes])
+                  ]),
                 ],
                 height: 120,
                 width: sheetWidth,

--- a/catalog/lib/scale_row.dart
+++ b/catalog/lib/scale_row.dart
@@ -56,7 +56,9 @@ class ScaleRow extends StatelessWidget {
               scrollDirection: Axis.horizontal,
               child: SimpleSheetMusic(
                 staffs: [
-                  Staff([Measure([clef, ...notes])]),
+                  Staff([
+                    Measure([clef, ...notes])
+                  ]),
                 ],
                 height: 120,
                 width: sheetWidth,

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -90,7 +90,9 @@ class SimpleSheetMusicDemoState extends State {
             child: SimpleSheetMusic(
               height: height,
               width: width,
-              staffs: [Staff([measure1, measure2, measure3])],
+              staffs: [
+                Staff([measure1, measure2, measure3])
+              ],
             ),
           ),
         ));

--- a/lib/src/measure/measure_renderer.dart
+++ b/lib/src/measure/measure_renderer.dart
@@ -141,22 +141,6 @@ class MeasureRenderer {
     }
   }
 
-  /// Renders the measure on the given [canvas] with the specified [size].
-  void renderWithSize(
-    Canvas canvas,
-    Size size, {
-    required SheetMusicLayout layout,
-    required double measureInitialX,
-    required double staffLineCenterY,
-  }) {
-    render(
-      canvas,
-      layout: layout,
-      staffLineCenterY: staffLineCenterY,
-      symbolX: measureInitialX,
-    );
-  }
-
   void _renderStaffLine(
     Canvas canvas,
     SheetMusicLayout layout,

--- a/lib/src/music_objects/notes/chord_note/chord_note.dart
+++ b/lib/src/music_objects/notes/chord_note/chord_note.dart
@@ -559,14 +559,3 @@ class ChordNoteRenderer implements MusicalSymbolRenderer {
 
   double get _noteHeadWidthForLeger => noteHeadsBbox.width;
 }
-
-/// Helper class for chord note head metrics.
-class ChordNoteHeadMetrics {
-  const ChordNoteHeadMetrics(this.noteHeadPath, this.part);
-
-  final Path noteHeadPath;
-  final ChordNotePart part;
-
-  Pitch get pitch => part.pitch;
-  Rect get noteHeadRect => noteHeadPath.getBounds();
-}

--- a/test/golden_test/clef_golden_test.dart
+++ b/test/golden_test/clef_golden_test.dart
@@ -64,7 +64,9 @@ Widget _buildClefWidget(Clef clef) {
   return GoldenTestWrapper(
     child: SimpleSheetMusic(
       staffs: [
-        Staff([Measure([clef])]),
+        Staff([
+          Measure([clef])
+        ]),
       ],
       height: 150,
       width: 180,

--- a/test/mock/mock_sheet_music_layout.dart
+++ b/test/mock/mock_sheet_music_layout.dart
@@ -1,4 +1,0 @@
-import 'package:flutter_test/flutter_test.dart';
-import 'package:simple_sheet_music/src/sheet_music_layout.dart';
-
-class MockSheetMusicLayout extends Fake implements SheetMusicLayout {}

--- a/test/mock/mock_staff_renderer.dart
+++ b/test/mock/mock_staff_renderer.dart
@@ -1,9 +1,0 @@
-import 'package:flutter_test/flutter_test.dart';
-import 'package:simple_sheet_music/src/staff/staff_renderer.dart';
-
-class MockStaffRenderer extends Fake implements StaffRenderer {
-  MockStaffRenderer({this.width = 0});
-
-  @override
-  final double width;
-}

--- a/test/mock/mocks.dart
+++ b/test/mock/mocks.dart
@@ -4,6 +4,4 @@ export 'mock_measure.dart';
 export 'mock_measure_renderer.dart';
 export 'mock_musical_symbol.dart';
 export 'mock_musical_symbol_renderer.dart';
-export 'mock_sheet_music_layout.dart';
 export 'mock_sheet_music_metrics.dart';
-export 'mock_staff_renderer.dart';


### PR DESCRIPTION
## Summary
- Remove duplicate `ChordNoteHeadMetrics` class from `chord_note.dart` (already defined in `chord_note_part.dart`)
- Remove unused `MeasureRenderer.renderWithSize` method
- Remove unused mock files (`MockSheetMusicLayout`, `MockStaffRenderer`)

## Test plan
- [x] `dart analyze` passes with no errors
- [x] `flutter test` passes (82 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)