### PR TITLE
refactor: Remove layout/staffLineCenterY/symbolX args from MusicalSymbolRenderer

### DIFF
--- a/lib/src/measure/measure_renderer.dart
+++ b/lib/src/measure/measure_renderer.dart
@@ -81,12 +81,11 @@ class MeasureRenderer {
     var x = measureInitialX;
 
     for (final symbol in symbolRenderers) {
-      if (symbol.isHit(
-        position,
-        layout: layout,
-        staffLineCenterY: staffLineCenterY,
-        symbolX: x,
-      )) {
+      symbol
+        ..layout = layout
+        ..staffLineCenterY = staffLineCenterY
+        ..symbolX = x;
+      if (symbol.isHit(position)) {
         return symbol;
       }
       x += symbol.width + symbol.margin.horizontal / layout.canvasScale;
@@ -131,12 +130,11 @@ class MeasureRenderer {
 
     // Render all symbols (including barlines)
     for (final symbol in symbolRenderers) {
-      symbol.render(
-        canvas,
-        layout: layout,
-        staffLineCenterY: staffLineCenterY,
-        symbolX: x,
-      );
+      symbol
+        ..layout = layout
+        ..staffLineCenterY = staffLineCenterY
+        ..symbolX = x
+        ..render(canvas);
       x += symbol.width + symbol.margin.horizontal / layout.canvasScale;
     }
   }

--- a/lib/src/music_objects/barline/barline.dart
+++ b/lib/src/music_objects/barline/barline.dart
@@ -49,9 +49,9 @@ class BarlineRenderer implements MusicalSymbolRenderer {
   final GlyphMetadata metadata;
   final Barline barline;
 
-  late final SheetMusicLayout _layout;
-  late final double _staffLineCenterY;
-  late final double _symbolX;
+  late SheetMusicLayout _layout;
+  late double _staffLineCenterY;
+  late double _symbolX;
 
   @override
   set layout(SheetMusicLayout value) => _layout = value;

--- a/lib/src/music_objects/barline/barline.dart
+++ b/lib/src/music_objects/barline/barline.dart
@@ -41,13 +41,26 @@ class Barline implements MusicalSymbol {
 ///
 /// This class is internal and not exported from the library.
 class BarlineRenderer implements MusicalSymbolRenderer {
-  const BarlineRenderer(
+  BarlineRenderer(
     this.barline,
     this.metadata,
   );
 
   final GlyphMetadata metadata;
   final Barline barline;
+
+  late final SheetMusicLayout _layout;
+  late final double _staffLineCenterY;
+  late final double _symbolX;
+
+  @override
+  set layout(SheetMusicLayout value) => _layout = value;
+
+  @override
+  set staffLineCenterY(double value) => _staffLineCenterY = value;
+
+  @override
+  set symbolX(double value) => _symbolX = value;
 
   /// The barline type.
   BarlineType get barlineType => barline.barlineType;
@@ -94,18 +107,13 @@ class BarlineRenderer implements MusicalSymbolRenderer {
   EdgeInsets get margin => barline.margin;
 
   @override
-  void render(
-    Canvas canvas, {
-    required SheetMusicLayout layout,
-    required double staffLineCenterY,
-    required double symbolX,
-  }) {
+  void render(Canvas canvas) {
     if (!shouldRender) {
       return;
     }
 
-    final x = symbolX + margin.left / layout.canvasScale;
-    final topY = staffLineCenterY - barlineHeight / 2;
+    final x = _symbolX + margin.left / _layout.canvasScale;
+    final topY = _staffLineCenterY - barlineHeight / 2;
 
     switch (barlineType) {
       case BarlineType.none:
@@ -139,18 +147,13 @@ class BarlineRenderer implements MusicalSymbolRenderer {
   }
 
   @override
-  bool isHit(
-    Offset position, {
-    required SheetMusicLayout layout,
-    required double staffLineCenterY,
-    required double symbolX,
-  }) {
+  bool isHit(Offset position) {
     if (!shouldRender) {
       return false;
     }
 
-    final x = symbolX + margin.left / layout.canvasScale;
-    final topY = staffLineCenterY - barlineHeight / 2;
+    final x = _symbolX + margin.left / _layout.canvasScale;
+    final topY = _staffLineCenterY - barlineHeight / 2;
     final hitArea = Rect.fromLTWH(x, topY, width, barlineHeight);
 
     return hitArea.contains(position);

--- a/lib/src/music_objects/clef/clef.dart
+++ b/lib/src/music_objects/clef/clef.dart
@@ -50,13 +50,26 @@ class Clef implements MusicalSymbol {
 
 /// Renders the clef symbol and provides its metrics.
 class ClefRenderer implements MusicalSymbolRenderer {
-  const ClefRenderer(
+  ClefRenderer(
     this.clef,
     this.paths,
   );
 
   final GlyphPaths paths;
   final Clef clef;
+
+  late final SheetMusicLayout _layout;
+  late final double _staffLineCenterY;
+  late final double _symbolX;
+
+  @override
+  set layout(SheetMusicLayout value) => _layout = value;
+
+  @override
+  set staffLineCenterY(double value) => _staffLineCenterY = value;
+
+  @override
+  set symbolX(double value) => _symbolX = value;
 
   // Metrics properties
 
@@ -102,46 +115,20 @@ class ClefRenderer implements MusicalSymbolRenderer {
   // Rendering methods
 
   @override
-  void render(
-    Canvas canvas, {
-    required SheetMusicLayout layout,
-    required double staffLineCenterY,
-    required double symbolX,
-  }) {
+  void render(Canvas canvas) {
     final p = Paint()..color = color;
-    canvas.drawPath(_renderPath(layout, staffLineCenterY, symbolX), p);
+    canvas.drawPath(_renderPath(), p);
   }
 
   @override
-  bool isHit(
-    Offset position, {
-    required SheetMusicLayout layout,
-    required double staffLineCenterY,
-    required double symbolX,
-  }) =>
-      _renderArea(layout, staffLineCenterY, symbolX).contains(position);
+  bool isHit(Offset position) => _renderArea().contains(position);
 
-  Offset _renderOffset(
-    SheetMusicLayout layout,
-    double staffLineCenterY,
-    double symbolX,
-  ) =>
-      Offset(symbolX, staffLineCenterY) + _marginOffset(layout);
+  Offset get _renderOffset =>
+      Offset(_symbolX, _staffLineCenterY) + _marginOffset;
 
-  Offset _marginOffset(SheetMusicLayout layout) =>
-      Offset(marginLeft, 0) / layout.canvasScale;
+  Offset get _marginOffset => Offset(marginLeft, 0) / _layout.canvasScale;
 
-  Rect _renderArea(
-    SheetMusicLayout layout,
-    double staffLineCenterY,
-    double symbolX,
-  ) =>
-      bbox.shift(_renderOffset(layout, staffLineCenterY, symbolX));
+  Rect _renderArea() => bbox.shift(_renderOffset);
 
-  Path _renderPath(
-    SheetMusicLayout layout,
-    double staffLineCenterY,
-    double symbolX,
-  ) =>
-      path.shift(_renderOffset(layout, staffLineCenterY, symbolX));
+  Path _renderPath() => path.shift(_renderOffset);
 }

--- a/lib/src/music_objects/clef/clef.dart
+++ b/lib/src/music_objects/clef/clef.dart
@@ -58,9 +58,9 @@ class ClefRenderer implements MusicalSymbolRenderer {
   final GlyphPaths paths;
   final Clef clef;
 
-  late final SheetMusicLayout _layout;
-  late final double _staffLineCenterY;
-  late final double _symbolX;
+  late SheetMusicLayout _layout;
+  late double _staffLineCenterY;
+  late double _symbolX;
 
   @override
   set layout(SheetMusicLayout value) => _layout = value;

--- a/lib/src/music_objects/interface/musical_symbol_renderer.dart
+++ b/lib/src/music_objects/interface/musical_symbol_renderer.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: avoid_setters_without_getters
+
 import 'package:flutter/rendering.dart';
 import 'package:simple_sheet_music/src/sheet_music_layout.dart';
 
@@ -15,19 +17,18 @@ abstract class MusicalSymbolRenderer {
   /// The margin around the musical symbol. Vertical margin is not used.
   EdgeInsets get margin;
 
+  /// Sets the layout for rendering.
+  set layout(SheetMusicLayout value);
+
+  /// Sets the Y coordinate of the staff line center.
+  set staffLineCenterY(double value);
+
+  /// Sets the X coordinate of the symbol.
+  set symbolX(double value);
+
   /// Checks if the symbol is hit at the given position.
-  bool isHit(
-    Offset position, {
-    required SheetMusicLayout layout,
-    required double staffLineCenterY,
-    required double symbolX,
-  });
+  bool isHit(Offset position);
 
   /// Renders the symbol on the given canvas.
-  void render(
-    Canvas canvas, {
-    required SheetMusicLayout layout,
-    required double staffLineCenterY,
-    required double symbolX,
-  });
+  void render(Canvas canvas);
 }

--- a/lib/src/music_objects/key_signature/key_signature.dart
+++ b/lib/src/music_objects/key_signature/key_signature.dart
@@ -197,6 +197,20 @@ class KeySignatureRenderer implements MusicalSymbolRenderer {
   final GlyphPaths paths;
   final KeySignature keySignature;
 
+  // ignore: unused_field
+  late final SheetMusicLayout _layout;
+  late final double _staffLineCenterY;
+  late final double _symbolX;
+
+  @override
+  set layout(SheetMusicLayout value) => _layout = value;
+
+  @override
+  set staffLineCenterY(double value) => _staffLineCenterY = value;
+
+  @override
+  set symbolX(double value) => _symbolX = value;
+
   // Metrics properties
 
   bool get hasParts => keySignatureType.hasParts;
@@ -272,13 +286,8 @@ class KeySignatureRenderer implements MusicalSymbolRenderer {
   // Rendering methods
 
   @override
-  void render(
-    Canvas canvas, {
-    required SheetMusicLayout layout,
-    required double staffLineCenterY,
-    required double symbolX,
-  }) {
-    final renderOffset = Offset(symbolX, staffLineCenterY);
+  void render(Canvas canvas) {
+    final renderOffset = Offset(_symbolX, _staffLineCenterY);
     for (final part in keySignatureParts) {
       part.render(
         canvas,
@@ -289,18 +298,12 @@ class KeySignatureRenderer implements MusicalSymbolRenderer {
   }
 
   @override
-  bool isHit(
-    Offset position, {
-    required SheetMusicLayout layout,
-    required double staffLineCenterY,
-    required double symbolX,
-  }) {
+  bool isHit(Offset position) {
     throw UnimplementedError();
   }
 
   /// Returns the render area for the given position.
-  Rect renderArea(double staffLineCenterY, double symbolX) =>
-      overallBbox.shift(Offset(symbolX, staffLineCenterY));
+  Rect get renderArea => overallBbox.shift(Offset(_symbolX, _staffLineCenterY));
 }
 
 class KeySignaturePart {

--- a/lib/src/music_objects/key_signature/key_signature.dart
+++ b/lib/src/music_objects/key_signature/key_signature.dart
@@ -198,9 +198,9 @@ class KeySignatureRenderer implements MusicalSymbolRenderer {
   final KeySignature keySignature;
 
   // ignore: unused_field
-  late final SheetMusicLayout _layout;
-  late final double _staffLineCenterY;
-  late final double _symbolX;
+  late SheetMusicLayout _layout;
+  late double _staffLineCenterY;
+  late double _symbolX;
 
   @override
   set layout(SheetMusicLayout value) => _layout = value;

--- a/lib/src/music_objects/notes/chord_note/chord_note.dart
+++ b/lib/src/music_objects/notes/chord_note/chord_note.dart
@@ -77,9 +77,9 @@ class ChordNoteRenderer implements MusicalSymbolRenderer {
   final GlyphPaths path;
   final ChordNote note;
 
-  late final SheetMusicLayout _layout;
-  late final double _staffLineCenterY;
-  late final double _symbolX;
+  late SheetMusicLayout _layout;
+  late double _staffLineCenterY;
+  late double _symbolX;
 
   @override
   set layout(SheetMusicLayout value) => _layout = value;

--- a/lib/src/music_objects/notes/chord_note/chord_note.dart
+++ b/lib/src/music_objects/notes/chord_note/chord_note.dart
@@ -77,6 +77,19 @@ class ChordNoteRenderer implements MusicalSymbolRenderer {
   final GlyphPaths path;
   final ChordNote note;
 
+  late final SheetMusicLayout _layout;
+  late final double _staffLineCenterY;
+  late final double _symbolX;
+
+  @override
+  set layout(SheetMusicLayout value) => _layout = value;
+
+  @override
+  set staffLineCenterY(double value) => _staffLineCenterY = value;
+
+  @override
+  set symbolX(double value) => _symbolX = value;
+
   List<ChordNotePart> get _noteParts => note.noteParts;
 
   List<ChordNoteHeadMetrics>? _noteHeadsCache;
@@ -437,27 +450,16 @@ class ChordNoteRenderer implements MusicalSymbolRenderer {
   // Rendering methods
 
   @override
-  bool isHit(
-    Offset position, {
-    required SheetMusicLayout layout,
-    required double staffLineCenterY,
-    required double symbolX,
-  }) =>
-      _renderArea(layout, staffLineCenterY, symbolX).contains(position);
+  bool isHit(Offset position) => _renderArea.contains(position);
 
   @override
-  void render(
-    Canvas canvas, {
-    required SheetMusicLayout layout,
-    required double staffLineCenterY,
-    required double symbolX,
-  }) {
-    final renderOffset = _renderOffset(layout, staffLineCenterY, symbolX);
+  void render(Canvas canvas) {
+    final renderOffset = _renderOffset;
     _renderNoteHead(canvas, renderOffset);
     _renderFlag(canvas, renderOffset);
     _renderAccidentals(canvas, renderOffset);
     _renderStem(canvas, renderOffset);
-    _renderLegerLine(canvas, layout, staffLineCenterY, symbolX);
+    _renderLegerLine(canvas);
   }
 
   void _renderNoteHead(Canvas canvas, Offset renderOffset) {
@@ -471,12 +473,7 @@ class ChordNoteRenderer implements MusicalSymbolRenderer {
     }
   }
 
-  Rect _renderArea(
-    SheetMusicLayout layout,
-    double staffLineCenterY,
-    double symbolX,
-  ) =>
-      _bbox.shift(_renderOffset(layout, staffLineCenterY, symbolX));
+  Rect get _renderArea => _bbox.shift(_renderOffset);
 
   void _renderAccidentals(Canvas canvas, Offset renderOffset) {
     for (final accidental in accidentalMetricses) {
@@ -514,43 +511,33 @@ class ChordNoteRenderer implements MusicalSymbolRenderer {
     );
   }
 
-  Offset _renderOffset(
-    SheetMusicLayout layout,
-    double staffLineCenterY,
-    double symbolX,
-  ) =>
-      Offset(symbolX, staffLineCenterY) + _marginOffset(layout);
+  Offset get _renderOffset =>
+      Offset(_symbolX, _staffLineCenterY) + _marginOffset;
 
-  Offset _marginOffset(SheetMusicLayout layout) =>
-      Offset(margin.left / layout.canvasScale, 0);
+  Offset get _marginOffset => Offset(margin.left / _layout.canvasScale, 0);
 
   double get _legerLineWidth => legerLineExtension * 2 + _noteHeadWidthForLeger;
 
   double get _legerLineThickness => legerLineThickness;
 
-  void _renderLegerLine(
-    Canvas canvas,
-    SheetMusicLayout layout,
-    double staffLineCenterY,
-    double symbolX,
-  ) {
-    final renderOffset = _renderOffset(layout, staffLineCenterY, symbolX);
+  void _renderLegerLine(Canvas canvas) {
+    final renderOffset = _renderOffset;
     final noteHeadRenderArea = noteHeadsBbox.shift(renderOffset);
     final noteHeadLeftX = noteHeadRenderArea.left;
     final noteHeadCenterX = noteHeadLeftX + _noteHeadWidthForLeger / 2;
 
     LegerLineRenderer(
-      layout.lineColor,
+      _layout.lineColor,
       uppestNotePosition,
-      staffLineCenterY: staffLineCenterY,
+      staffLineCenterY: _staffLineCenterY,
       noteCenterX: noteHeadCenterX,
       legerLineWidth: _legerLineWidth,
       legerLineThickness: _legerLineThickness,
     ).render(canvas);
     LegerLineRenderer(
-      layout.lineColor,
+      _layout.lineColor,
       lowestNotePosition,
-      staffLineCenterY: staffLineCenterY,
+      staffLineCenterY: _staffLineCenterY,
       noteCenterX: noteHeadCenterX,
       legerLineWidth: _legerLineWidth,
       legerLineThickness: _legerLineThickness,

--- a/lib/src/music_objects/notes/single_note/note.dart
+++ b/lib/src/music_objects/notes/single_note/note.dart
@@ -74,9 +74,9 @@ class NoteRenderer implements MusicalSymbolRenderer {
   // The note object associated with these metrics.
   final Note note;
 
-  late final SheetMusicLayout _layout;
-  late final double _staffLineCenterY;
-  late final double _symbolX;
+  late SheetMusicLayout _layout;
+  late double _staffLineCenterY;
+  late double _symbolX;
 
   @override
   set layout(SheetMusicLayout value) => _layout = value;

--- a/lib/src/music_objects/notes/single_note/note.dart
+++ b/lib/src/music_objects/notes/single_note/note.dart
@@ -55,7 +55,7 @@ class Note implements MusicalSymbol {
 
 /// A class that renders a musical note symbol and provides its metrics.
 class NoteRenderer implements MusicalSymbolRenderer {
-  const NoteRenderer(
+  NoteRenderer(
     this.note,
     this.context,
     this.metadata,
@@ -73,6 +73,19 @@ class NoteRenderer implements MusicalSymbolRenderer {
 
   // The note object associated with these metrics.
   final Note note;
+
+  late final SheetMusicLayout _layout;
+  late final double _staffLineCenterY;
+  late final double _symbolX;
+
+  @override
+  set layout(SheetMusicLayout value) => _layout = value;
+
+  @override
+  set staffLineCenterY(double value) => _staffLineCenterY = value;
+
+  @override
+  set symbolX(double value) => _symbolX = value;
 
   // Metrics properties
 
@@ -306,27 +319,16 @@ class NoteRenderer implements MusicalSymbolRenderer {
   // Rendering methods
 
   @override
-  bool isHit(
-    Offset position, {
-    required SheetMusicLayout layout,
-    required double staffLineCenterY,
-    required double symbolX,
-  }) =>
-      _renderArea(layout, staffLineCenterY, symbolX).contains(position);
+  bool isHit(Offset position) => _renderArea.contains(position);
 
   @override
-  void render(
-    Canvas canvas, {
-    required SheetMusicLayout layout,
-    required double staffLineCenterY,
-    required double symbolX,
-  }) {
-    final renderOffset = _renderOffset(layout, staffLineCenterY, symbolX);
+  void render(Canvas canvas) {
+    final renderOffset = _renderOffset;
     _renderNoteHead(canvas, renderOffset);
     _renderFlag(canvas, renderOffset);
     _renderAccidental(canvas, renderOffset);
     _renderStem(canvas, renderOffset);
-    _renderLegerLine(canvas, layout, staffLineCenterY, symbolX);
+    _renderLegerLine(canvas);
   }
 
   void _renderNoteHead(Canvas canvas, Offset renderOffset) {
@@ -372,43 +374,28 @@ class NoteRenderer implements MusicalSymbolRenderer {
   }
 
   /// Returns the render offset, which is the sum of the symbol X position and the staff line center Y position.
-  Offset _renderOffset(
-    SheetMusicLayout layout,
-    double staffLineCenterY,
-    double symbolX,
-  ) =>
-      Offset(symbolX, staffLineCenterY) + _marginOffset(layout);
+  Offset get _renderOffset =>
+      Offset(_symbolX, _staffLineCenterY) + _marginOffset;
 
   /// Returns the margin offset, which is the left margin of the note divided by the canvas scale.
-  Offset _marginOffset(SheetMusicLayout layout) =>
-      Offset(margin.left / layout.canvasScale, 0);
+  Offset get _marginOffset => Offset(margin.left / _layout.canvasScale, 0);
 
   /// Returns the render area of the note, shifted by the render offset.
-  Rect _renderArea(
-    SheetMusicLayout layout,
-    double staffLineCenterY,
-    double symbolX,
-  ) =>
-      bbox.shift(_renderOffset(layout, staffLineCenterY, symbolX));
+  Rect get _renderArea => bbox.shift(_renderOffset);
 
   /// Returns the width of the leger line, which is twice the leger line extension plus the note head width.
   double get _legerLineWidth => legerLineExtension * 2 + noteHeadWidth;
 
   /// Renders the leger line.
-  void _renderLegerLine(
-    Canvas canvas,
-    SheetMusicLayout layout,
-    double staffLineCenterY,
-    double symbolX,
-  ) {
-    final renderOffset = _renderOffset(layout, staffLineCenterY, symbolX);
+  void _renderLegerLine(Canvas canvas) {
+    final renderOffset = _renderOffset;
     final noteHeadLeftX = renderOffset.dx + this.noteHeadLeftX;
     final noteHeadCenterX = noteHeadLeftX + noteHeadWidth / 2;
 
     LegerLineRenderer(
-      layout.lineColor,
+      _layout.lineColor,
       stavePosition,
-      staffLineCenterY: staffLineCenterY,
+      staffLineCenterY: _staffLineCenterY,
       noteCenterX: noteHeadCenterX,
       legerLineWidth: _legerLineWidth,
       legerLineThickness: legerLineThickness,

--- a/lib/src/music_objects/rest/rest.dart
+++ b/lib/src/music_objects/rest/rest.dart
@@ -52,9 +52,9 @@ class RestRenderer implements MusicalSymbolRenderer {
   final GlyphPaths paths;
   final Rest rest;
 
-  late final SheetMusicLayout _layout;
-  late final double _staffLineCenterY;
-  late final double _symbolX;
+  late SheetMusicLayout _layout;
+  late double _staffLineCenterY;
+  late double _symbolX;
 
   @override
   set layout(SheetMusicLayout value) => _layout = value;

--- a/lib/src/music_objects/rest/rest.dart
+++ b/lib/src/music_objects/rest/rest.dart
@@ -40,7 +40,7 @@ class Rest implements MusicalSymbol {
 
 /// Renders a rest in sheet music and provides its metrics.
 class RestRenderer implements MusicalSymbolRenderer {
-  const RestRenderer(
+  RestRenderer(
     this.rest,
     this.context,
     this.metadata,
@@ -51,6 +51,19 @@ class RestRenderer implements MusicalSymbolRenderer {
   final GlyphMetadata metadata;
   final GlyphPaths paths;
   final Rest rest;
+
+  late final SheetMusicLayout _layout;
+  late final double _staffLineCenterY;
+  late final double _symbolX;
+
+  @override
+  set layout(SheetMusicLayout value) => _layout = value;
+
+  @override
+  set staffLineCenterY(double value) => _staffLineCenterY = value;
+
+  @override
+  set symbolX(double value) => _symbolX = value;
 
   // Metrics properties
 
@@ -79,49 +92,23 @@ class RestRenderer implements MusicalSymbolRenderer {
   // Rendering methods
 
   @override
-  bool isHit(
-    Offset position, {
-    required SheetMusicLayout layout,
-    required double staffLineCenterY,
-    required double symbolX,
-  }) {
+  bool isHit(Offset position) {
     throw UnimplementedError();
   }
 
   @override
-  void render(
-    Canvas canvas, {
-    required SheetMusicLayout layout,
-    required double staffLineCenterY,
-    required double symbolX,
-  }) =>
-      canvas.drawPath(
-        _renderPath(layout, staffLineCenterY, symbolX),
+  void render(Canvas canvas) => canvas.drawPath(
+        _renderPath(),
         Paint()..color = rest.color,
       );
 
-  Offset _renderOffset(
-    SheetMusicLayout layout,
-    double staffLineCenterY,
-    double symbolX,
-  ) =>
-      Offset(symbolX, staffLineCenterY) + _marginOffset(layout);
+  Offset get _renderOffset =>
+      Offset(_symbolX, _staffLineCenterY) + _marginOffset;
 
-  Offset _marginOffset(SheetMusicLayout layout) =>
-      Offset(leftMargin, 0) / layout.canvasScale;
+  Offset get _marginOffset => Offset(leftMargin, 0) / _layout.canvasScale;
 
-  Path _renderPath(
-    SheetMusicLayout layout,
-    double staffLineCenterY,
-    double symbolX,
-  ) =>
-      path.shift(_renderOffset(layout, staffLineCenterY, symbolX));
+  Path _renderPath() => path.shift(_renderOffset);
 
   /// Returns the render area for the given position.
-  Rect renderArea(
-    SheetMusicLayout layout,
-    double staffLineCenterY,
-    double symbolX,
-  ) =>
-      _renderPath(layout, staffLineCenterY, symbolX).getBounds();
+  Rect get renderArea => _renderPath().getBounds();
 }

--- a/lib/src/music_objects/time_signature/time_signature.dart
+++ b/lib/src/music_objects/time_signature/time_signature.dart
@@ -165,9 +165,9 @@ class TimeSignatureRenderer implements MusicalSymbolRenderer {
   final TimeSignature timeSignature;
   final GlyphPaths paths;
 
-  late final SheetMusicLayout _layout;
-  late final double _staffLineCenterY;
-  late final double _symbolX;
+  late SheetMusicLayout _layout;
+  late double _staffLineCenterY;
+  late double _symbolX;
 
   @override
   set layout(SheetMusicLayout value) => _layout = value;

--- a/lib/src/music_objects/time_signature/time_signature.dart
+++ b/lib/src/music_objects/time_signature/time_signature.dart
@@ -165,6 +165,19 @@ class TimeSignatureRenderer implements MusicalSymbolRenderer {
   final TimeSignature timeSignature;
   final GlyphPaths paths;
 
+  late final SheetMusicLayout _layout;
+  late final double _staffLineCenterY;
+  late final double _symbolX;
+
+  @override
+  set layout(SheetMusicLayout value) => _layout = value;
+
+  @override
+  set staffLineCenterY(double value) => _staffLineCenterY = value;
+
+  @override
+  set symbolX(double value) => _symbolX = value;
+
   /// Tracking space between digits (in staff space units).
   static const _digitTracking = 0.04;
 
@@ -279,46 +292,20 @@ class TimeSignatureRenderer implements MusicalSymbolRenderer {
   Color get _color => timeSignature.color;
 
   @override
-  void render(
-    Canvas canvas, {
-    required SheetMusicLayout layout,
-    required double staffLineCenterY,
-    required double symbolX,
-  }) {
+  void render(Canvas canvas) {
     final paint = Paint()..color = _color;
-    canvas.drawPath(_renderPath(layout, staffLineCenterY, symbolX), paint);
+    canvas.drawPath(_renderPath(), paint);
   }
 
   @override
-  bool isHit(
-    Offset position, {
-    required SheetMusicLayout layout,
-    required double staffLineCenterY,
-    required double symbolX,
-  }) =>
-      _renderArea(layout, staffLineCenterY, symbolX).contains(position);
+  bool isHit(Offset position) => _renderArea().contains(position);
 
-  Offset _renderOffset(
-    SheetMusicLayout layout,
-    double staffLineCenterY,
-    double symbolX,
-  ) =>
-      Offset(symbolX, staffLineCenterY) + _marginOffset(layout);
+  Offset get _renderOffset =>
+      Offset(_symbolX, _staffLineCenterY) + _marginOffset;
 
-  Offset _marginOffset(SheetMusicLayout layout) =>
-      Offset(_marginLeft, 0) / layout.canvasScale;
+  Offset get _marginOffset => Offset(_marginLeft, 0) / _layout.canvasScale;
 
-  Rect _renderArea(
-    SheetMusicLayout layout,
-    double staffLineCenterY,
-    double symbolX,
-  ) =>
-      bbox.shift(_renderOffset(layout, staffLineCenterY, symbolX));
+  Rect _renderArea() => bbox.shift(_renderOffset);
 
-  Path _renderPath(
-    SheetMusicLayout layout,
-    double staffLineCenterY,
-    double symbolX,
-  ) =>
-      path.shift(_renderOffset(layout, staffLineCenterY, symbolX));
+  Path _renderPath() => path.shift(_renderOffset);
 }

--- a/test/mock/mock_musical_symbol_renderer.dart
+++ b/test/mock/mock_musical_symbol_renderer.dart
@@ -28,9 +28,9 @@ class MockMusicalSymbolRenderer extends Fake implements MusicalSymbolRenderer {
   @override
   final EdgeInsets margin;
 
-  late final SheetMusicLayout _layout;
-  late final double _staffLineCenterY;
-  late final double _symbolX;
+  late SheetMusicLayout _layout;
+  late double _staffLineCenterY;
+  late double _symbolX;
 
   @override
   set layout(SheetMusicLayout value) => _layout = value;

--- a/test/mock/mock_musical_symbol_renderer.dart
+++ b/test/mock/mock_musical_symbol_renderer.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: unused_field
+
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:simple_sheet_music/src/music_objects/clef/clef_type.dart';
@@ -26,20 +28,22 @@ class MockMusicalSymbolRenderer extends Fake implements MusicalSymbolRenderer {
   @override
   final EdgeInsets margin;
 
-  @override
-  bool isHit(
-    Offset position, {
-    required SheetMusicLayout layout,
-    required double staffLineCenterY,
-    required double symbolX,
-  }) =>
-      false;
+  late final SheetMusicLayout _layout;
+  late final double _staffLineCenterY;
+  late final double _symbolX;
 
   @override
-  void render(
-    Canvas canvas, {
-    required SheetMusicLayout layout,
-    required double staffLineCenterY,
-    required double symbolX,
-  }) {}
+  set layout(SheetMusicLayout value) => _layout = value;
+
+  @override
+  set staffLineCenterY(double value) => _staffLineCenterY = value;
+
+  @override
+  set symbolX(double value) => _symbolX = value;
+
+  @override
+  bool isHit(Offset position) => false;
+
+  @override
+  void render(Canvas canvas) {}
 }


### PR DESCRIPTION
## Summary
- Replace method arguments with setter-based property injection pattern for `MusicalSymbolRenderer`
- Add `layout`, `staffLineCenterY`, `symbolX` setters to interface
- Update `isHit()` and `render()` methods to use injected properties instead of arguments
- Update `MeasureRenderer` to set properties via cascade before calling methods

## Changes
| File | Change |
|------|--------|
| `musical_symbol_renderer.dart` | Add setters, remove method args |
| `measure_renderer.dart` | Set properties via cascade before method calls |
| `clef.dart` | Remove const constructor, add late final fields |
| `barline.dart` | Remove const constructor, add late final fields |
| `rest.dart` | Remove const constructor, add late final fields |
| `note.dart` | Remove const constructor, add late final fields |
| `time_signature.dart` | Add late final fields |
| `key_signature.dart` | Add late final fields |
| `chord_note.dart` | Add late final fields |
| `mock_musical_symbol_renderer.dart` | Update mock implementation |

## Test plan
- [x] All 82 tests pass
- [x] flutter analyze passes (only external package warning remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)